### PR TITLE
Added new step 2 to install GH Repos extension

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -3,11 +3,12 @@
 ## Setup
 
 1. Install [VS Code](https://code.visualstudio.com/download)
-2. Open VS Code and select **Clone Git Repository** on the splash page
-3. Paste `https://github.com/CDCgov/NEDSS-SystemAdminGuide` and press Enter
-4. Choose your root user folder as the location
-5. Select **Yes** when prompted to open the repo folder
-6. Open a terminal: **Terminal > New Terminal**
+2. Install the [GitHub Repositories extension](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub), if you don't have it already.
+3. Open VS Code and select **Clone Git Repository** on the splash page
+4. Paste `https://github.com/CDCgov/NEDSS-SystemAdminGuide` and press Enter
+5. Choose your root user folder as the location
+6. Select **Yes** when prompted to open the repo folder
+7. Open a terminal: **Terminal > New Terminal**
 
 Your prompt should look something like:
 ```


### PR DESCRIPTION
I added a new step 2 to WORKFLOW.md (encouraging folks to download the GH Repos extension if they hadn't already - I wasn't able to set up VS Code without doing this!).