### PR TITLE
[STLT-466] Create doc vars and checklist for 7 Admin Guide version releases

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,19 @@
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var wrap = document.querySelector('.main-content-wrap');
+    if (!wrap) return;
+    var banner = document.createElement('div');
+    var match = window.location.pathname.match(/\/previous_versions\/release-([^/]+)\//);
+    if (match) {
+      banner.className = 'version-banner version-banner--archived';
+      banner.textContent = 'Archived: NBS ' + match[1];
+    } else {
+      banner.className = 'version-banner';
+      banner.textContent = 'NBS {{ site.version_latest }}';
+    }
+    wrap.parentNode.insertBefore(banner, wrap);
+  });
+</script>
 <link rel="icon" href="{{ '/assets/images/favicon/favicon.ico' | relative_url }}" sizes="any">
 <link rel="icon" type="image/svg+xml" href="{{ '/assets/images/favicon/favicon.svg' | relative_url }}">
 <link rel="icon" type="image/png" sizes="96x96" href="{{ '/assets/images/favicon/favicon-96x96.png' | relative_url }}">

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -10,3 +10,15 @@
     color: #008A17;
     font-weight: bold;
 }
+.version-banner {
+    padding: 0.35rem 1.5rem;
+    font-size: 0.75rem;
+    color: $grey-dk-100;
+    background-color: $sidebar-color;
+    border-bottom: 1px solid $border-color;
+}
+.version-banner--archived {
+    background-color: #fdf3cd;
+    color: #7a5c00;
+    border-bottom-color: #f0d060;
+}

--- a/contributing/release-checklist.md
+++ b/contributing/release-checklist.md
@@ -21,82 +21,26 @@ Identify the following values for the new release before starting any checklist 
 
 ---
 
+## Release workflow overview
+
+Each release has two phases that must happen in this order (follow the explicit steps in the [Checklist](#checklist) section):
+
+**Phase 1 — Archive the previous release (see [step 1](#1-archive-the-previous-release))**
+
+Cut a `release-X.XX` branch from `main` *before* any new-release content is merged. This preserves the current release docs as a snapshot. On that branch, replace Liquid variables with hardcoded version values and push. The build workflow discovers the branch automatically and adds it to Previous Versions.
+
+**Phase 2 — Update main for the new release (see [steps 2–7](#2-update-version-variables))**
+
+With the archive in place, update `main`: bump the version variables, confirm the guide reflects the new version, review version-sensitive pages, and run quality checks.
+
+> Always complete phase 1 before merging new-release content to `main`. If the archive branch is cut after the version variables are updated, it will capture new-release content instead of the release being archived.
+{: .warning }
+
+---
+
 ## Checklist
 
-### 1. Update version variables
-
-- [ ] In `_config.yml`, update `version_latest` to the new version number (e.g., `7.13`).
-- [ ] In `_config.yml`, update `version_latest_tag` to the new version tag (e.g., `v7.13.0`).
-- [ ] Update the `title:` field in `_config.yml` to reflect the new version (e.g., `NBS 7.13 System Administrator Guide`).
-- [ ] Confirm the site builds without errors after the update.
-
-### 2. Confirm the guide title
-
-- [ ] Confirm the guide title reflects the new version (e.g., "NBS 7.13 System Administrator Guide").
-  The title is set in `_config.yml` and must be updated manually alongside `version_latest`.
-
-### 3. Confirm version-sensitive pages
-
-Every page that links to a GitHub repository at a specific version tag is version-sensitive.
-Links using `{{ site.version_latest_tag }}` update automatically when you update the variable
-in step 1. This step confirms those links resolve at the new tag and flags pages that also
-need manual content review.
-
-- [ ] Search the repo for any remaining hardcoded previous version tag (e.g., `v7.12.0`)
-  and update all instances to the new tag.
-- [ ] Work through the page list below and confirm each item.
-
-| Page | What to confirm |
-|------|----------------|
-| `docs/deploy-nbs7/quickstart.md` | NEDSS-Infrastructure and NEDSS-Helm chart README links resolve at the new tag. |
-| `docs/deploy-nbs7/deploy-on-aws/provision-aws.md` | NEDSS-Infrastructure Terraform README link resolves at the new tag. |
-| `docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.md` | NEDSS-Helm Traefik chart links resolve at the new tag. |
-| `docs/deploy-nbs7/real-time-reporting/real-time-reporting.md` | NEDSS-DataReporting script links and NEDSS-Helm secrets link resolve at the new tag. |
-| `docs/deploy-nbs7/real-time-reporting/liquibase.md` | NEDSS-Helm Liquibase chart link resolves at the new tag. |
-| `docs/deploy-nbs7/real-time-reporting/debezium.md` | NEDSS-Helm Debezium chart link resolves at the new tag. |
-| `docs/deploy-nbs7/real-time-reporting/kafka-connector.md` | NEDSS-Helm Kafka chart link resolves at the new tag. |
-| `docs/deploy-nbs7/real-time-reporting/rtr-java-services.md` | NEDSS-Helm RTR chart and NEDSS-Helm secrets links resolve at the new tag. Review the consolidation warning callout for accuracy. |
-| `docs/deploy-nbs7/real-time-reporting/data-compare-tool.md` | Both NEDSS-Helm links resolve at the new tag. NEDSS-DataCompare link stays at `main` — that repo has no version tags. |
-| `docs/deploy-nbs7/keycloak/keycloak-installation.md` | NEDSS-Helm Keycloak chart, SQL script, and realm JSON file links resolve at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/case-notification.md` | NEDSS-Helm Keycloak profile link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/data-ingestion.md` | NEDSS-Helm Data Ingestion chart link and NEDSS-DataIngestion DB scripts link resolve at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/elasticsearch.md` | NEDSS-Helm Elasticsearch chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/modernization-api.md` | NEDSS-Helm Modernization API chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/nifi.md` | NEDSS-Helm NiFi chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/nbs-gateway.md` | NEDSS-Helm NBS Gateway chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/data-processing.md` | NEDSS-Helm Data Processing chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/case-notification/debezium.md` | NEDSS-Helm Debezium chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/case-notification/data-extraction.md` | NEDSS-Helm Data Extraction chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/case-notification/case-notification-service.md` | NEDSS-Helm Case Notification Service chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/case-notification/api-testing.md` | NEDSS-Helm templates and NEDSS-NNDSS-Case-Notifications links resolve at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/nnd-service/deploy-data-sync-service-api-cloud.md` | NEDSS-Helm NND Service chart link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/validate-es-mapi-nifi/api-smoke-test.md` | NEDSS-Infrastructure `nbs-test-api.sh` script link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/validate-es-mapi-nifi/web-ui-smoke-test.md` | NEDSS-Infrastructure `nbs-test-webui.sh` script link resolves at the new tag. |
-| `docs/deploy-nbs7/microservices-deployment/nnd-service/on-prem-data-sync.md` | NEDSS-NNDSS scripts links resolve at the new tag. **Confirm the NEDSS-NNDSS release at the new tag includes a `vX.Y.Z.NEDSS.NBS.Modernized.Documentation.zip` asset** — this was absent from the v7.12.0 release. If the asset is missing, coordinate with the dev team before publishing. |
-| `docs/deploy-nbs7/microservices-deployment/nnd-service/on-prem-nnd-sync.md` | NEDSS-NNDSS README link resolves at the new tag. Same documentation zip caveat as `on-prem-data-sync.md` above. |
-| `docs/maintain-nbs7/eks-upgrade.md` | Update the Kubernetes versions table. Confirm the conditional add-ons step (Step 4) still reflects the correct `eks_nbs` module version behavior. *(Page not yet created as of 7.12.)* |
-
-> Add rows to this table as version-sensitive pages are identified.
-
-### 4. Review per-page version callouts
-
-Pages with a per-page version callout (e.g., "This page applies to NBS 7.12")
-are updated automatically when `version_latest` is updated in step 1.
-
-- [ ] Search the repo for any hardcoded version callouts and update them.
-
-> Add pages with callouts to this list as they are identified.
-
-### 5. Quality checks
-
-- [ ] Run a link checker or manually spot-check for broken links (historically a
-  known problem at release time).
-- [ ] Confirm all new or updated content meets Section 508 requirements (heading
-  structure, alt text, table formatting, hyperlink text). See [styles.md §10](styles.md#10-accessibility-compliance-record).
-- [ ] Confirm all new or updated content follows Global English and Google
-  Developer Style Guide conventions. See [styles.md](styles.md).
-
-### 6. Archive the previous release
+### 1. Archive the previous release
 
 The site uses branch-based archiving. Any branch named `release-*` is
 automatically discovered by the GitHub Actions build workflow, checked out into
@@ -110,7 +54,11 @@ using `_config.yml` from `main`, Liquid variables (`{{ site.version_latest }}`,
 **current** release values, not the archived ones. The variables must be
 replaced with hardcoded values on the release branch before it is pushed.
 
-- [ ] From the current `main`, create a new branch named `release-7.12` (see [workflow.md](workflow.md) for git command reference):
+> The version banner reads the archived version from the URL automatically and
+> does not require find-and-replace.
+{: .note }
+
+- [ ] From the current `main` — before any new-release content is merged — create a release branch named for the version being archived (e.g., `release-7.12`). See [workflow.md](workflow.md) for git command reference:
   ```
   git checkout -b release-7.12
   ```
@@ -123,8 +71,53 @@ replaced with hardcoded values on the release branch before it is pushed.
 - [ ] Confirm the archived release renders correctly and all links resolve.
 - [ ] Confirm the archived release appears correctly under "Previous Versions"
   in the sidebar.
+- [ ] Confirm the archived version banner shows the correct version (e.g., "Archived: NBS 7.12.0").
 
-### 7. Create a per-release Jira ticket
+### 2. Update version variables
+
+- [ ] In `_config.yml`, update `version_latest` to the new version number (e.g., `7.13`).
+- [ ] In `_config.yml`, update `version_latest_tag` to the new version tag (e.g., `v7.13.0`).
+- [ ] Update the `title:` field in `_config.yml` to reflect the new version (e.g., `NBS 7.13 System Administrator Guide`).
+- [ ] Update the `title:` field in `docs/deploy-nbs7.md` to the new version (e.g., `Deploy NBS 7.13`).
+- [ ] Confirm the site builds without errors after the update.
+
+> Updating `version_latest` also updates the version banner (shown on every page), the version callouts on the Introduction, Deploy, and Maintain section landing pages, and all pinned GitHub links that use `version_latest_tag`. The `docs/deploy-nbs7.md` title must be updated manually because Jekyll does not process Liquid variables in front matter.
+{: .note }
+
+### 3. Confirm the guide title
+
+- [ ] Confirm the live guide title shows the new version (e.g., "NBS 7.13 System Administrator Guide").
+- [ ] Confirm the Deploy section landing page title shows the new version (e.g., "Deploy NBS 7.13").
+
+### 4. Confirm version-sensitive pages
+
+Pages that link to a GitHub repository at a specific version tag use `{{ site.version_latest_tag }}`, which updates automatically when you update the variable in step 2.
+
+- [ ] Search the repo for any remaining hardcoded previous version tag (e.g., `v7.12.0`) and update all instances.
+- [ ] Run a link checker to confirm all `version_latest_tag`-pinned links resolve at the new tag (see step 5).
+
+The following pages require manual content review beyond link verification:
+
+| Page | What to review |
+|------|----------------|
+| `docs/deploy-nbs7/real-time-reporting/rtr-java-services.md` | Review the consolidation warning callout for accuracy. |
+| `docs/deploy-nbs7/real-time-reporting/data-compare-tool.md` | The NEDSS-DataCompare link is pinned to `main` — that repo has no version tags. Confirm this is still correct. |
+| `docs/deploy-nbs7/microservices-deployment/nnd-service/on-prem-data-sync.md` | Confirm the NEDSS-NNDSS release at the new tag includes a `vX.Y.Z.NEDSS.NBS.Modernized.Documentation.zip` asset. If missing, coordinate with the dev team before publishing. |
+| `docs/deploy-nbs7/microservices-deployment/nnd-service/on-prem-nnd-sync.md` | Same documentation zip caveat as `on-prem-data-sync.md`. |
+| `docs/maintain-nbs7/eks-upgrade.md` | Update the Kubernetes versions table. Confirm the conditional add-ons step still reflects correct module version behavior. *(Page not yet created as of 7.12.)* |
+
+> Add rows to this table as pages requiring manual review are identified.
+
+### 5. Quality checks
+
+- [ ] Run a link checker or manually spot-check for broken links (historically a
+  known problem at release time).
+- [ ] Confirm all new or updated content meets Section 508 requirements (heading
+  structure, alt text, table formatting, hyperlink text). See [styles.md §10](styles.md#10-accessibility-compliance-record).
+- [ ] Confirm all new or updated content follows Global English and Google
+  Developer Style Guide conventions. See [styles.md](styles.md).
+
+### 6. Create a per-release Jira ticket
 
 At the start of each release cycle, create a new Jira ticket in the STLT project
 under the [Admin Guide: polishing and hardening] epic. Use this checklist as the
@@ -133,7 +126,7 @@ into the new ticket, and track completion there.
 
 Suggested Jira ticket title: `Admin Guide: Update guide for NBS 7.XX release`
 
-### 8. Final review
+### 7. Final review
 
 - [ ] Confirm the live guide title shows the new version.
 - [ ] Confirm the site builds and deploys successfully on GitHub Pages.

--- a/contributing/release-checklist.md
+++ b/contributing/release-checklist.md
@@ -1,7 +1,6 @@
 # Admin Guide release checklist
 
-Use this checklist for each NBS 7 release. At the start of each release cycle,
-copy the checklist items into a new Jira ticket and track completion there.
+Use this checklist for each NBS 7 release.
 
 For the broader NBS release process (engineering, testing, beta, CDC approval),
 see the [Template] 6 Release Process Checklist in NBS Central.
@@ -10,7 +9,7 @@ see the [Template] 6 Release Process Checklist in NBS Central.
 
 ## Before you begin
 
-Identify the following values for the new release before starting any checklist items.
+Identify the following values and complete the setup steps before starting the checklist.
 
 | Value | Example | Notes |
 |---|---|---|
@@ -18,6 +17,8 @@ Identify the following values for the new release before starting any checklist 
 | New version tag | `v7.13.0` | Used in `version_latest_tag`; confirm tag exists in NEDSS-Infrastructure before starting |
 | Previous version number | `7.12` | Used in archiving steps |
 | Previous version tag | `v7.12.0` | Used in archiving steps |
+
+- [ ] Create a new Jira ticket in the STLT project under the **SysAdmin Guide: New release checklists** epic. Suggested title: `Admin Guide: Update guide for NBS X.XX release`. Copy the checklist items below as acceptance criteria and track completion there.
 
 ---
 
@@ -110,23 +111,14 @@ The following pages require manual content review beyond link verification:
 
 ### 5. Quality checks
 
-- [ ] Run a link checker or manually spot-check for broken links (historically a
+- [ ] Run the link checker `npm run lint` for broken links (historically a
   known problem at release time).
 - [ ] Confirm all new or updated content meets Section 508 requirements (heading
   structure, alt text, table formatting, hyperlink text). See [styles.md §10](styles.md#10-accessibility-compliance-record).
 - [ ] Confirm all new or updated content follows Global English and Google
   Developer Style Guide conventions. See [styles.md](styles.md).
 
-### 6. Create a per-release Jira ticket
-
-At the start of each release cycle, create a new Jira ticket in the STLT project
-under the [Admin Guide: polishing and hardening] epic. Use this checklist as the
-source of truth for line items. Copy the checklist items as acceptance criteria
-into the new ticket, and track completion there.
-
-Suggested Jira ticket title: `Admin Guide: Update guide for NBS 7.XX release`
-
-### 7. Final review
+### 6. Final review
 
 - [ ] Confirm the live guide title shows the new version.
 - [ ] Confirm the site builds and deploys successfully on GitHub Pages.

--- a/docs/deploy-nbs7.md
+++ b/docs/deploy-nbs7.md
@@ -3,12 +3,15 @@ title: Deploy NBS 7
 layout: page
 nav_order: 3
 has_children: true
-description: Step-by-step instructions for deploying NBS 7 in an AWS environment.
+description: Step-by-step instructions for deploying NBS {{ site.version_latest }}.
 ---
 
-# Deploy NBS 7
+# Deploy NBS {{ site.version_latest }}
 
 This section covers the full NBS 7 deployment process, from prerequisites and infrastructure setup through microservices deployment and go-live.
+
+> The procedures in this section reflect NBS {{ site.version_latest }}. For earlier releases, see **Previous Versions** in the sidebar.
+{: .note }
 
 <!--
 Before you begin, confirm that your NBS 6 version is compatible with your target NBS 7 version in the [NBS 6 and NBS 7 compatibility matrix](before-you-deploy/compatibility.html).

--- a/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.md
+++ b/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.md
@@ -21,8 +21,6 @@ redirect_from:
 # Initial Kubernetes deployment
 {: .no_toc }
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 This page explains how to deploy the core Kubernetes infrastructure services that NBS 7 requires before you install application components. Complete the sections in order. After you complete these steps, proceed to [Keycloak Installation](../../deploy-nbs7/keycloak/keycloak-installation.html).
 

--- a/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.md
+++ b/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.md
@@ -21,7 +21,6 @@ redirect_from:
 # Initial Kubernetes deployment
 {: .no_toc }
 
-
 This page explains how to deploy the core Kubernetes infrastructure services that NBS 7 requires before you install application components. Complete the sections in order. After you complete these steps, proceed to [Keycloak Installation](../../deploy-nbs7/keycloak/keycloak-installation.html).
 
 ## On this page

--- a/docs/deploy-nbs7/keycloak/keycloak-installation.md
+++ b/docs/deploy-nbs7/keycloak/keycloak-installation.md
@@ -19,7 +19,6 @@ redirect_from:
 1. TOC
 {:toc}
 
-
 The Keycloak Helm chart provides authentication for `modernization-api`, `nbs-gateway`, `data-ingestion-api`, and `nnd`. Locate the chart in the [NEDSS-Helm repository][nedss-helm-keycloak-chart] before beginning.
 
 ## Create the Keycloak database

--- a/docs/deploy-nbs7/keycloak/keycloak-installation.md
+++ b/docs/deploy-nbs7/keycloak/keycloak-installation.md
@@ -19,8 +19,6 @@ redirect_from:
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 The Keycloak Helm chart provides authentication for `modernization-api`, `nbs-gateway`, `data-ingestion-api`, and `nnd`. Locate the chart in the [NEDSS-Helm repository][nedss-helm-keycloak-chart] before beginning.
 

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/case-notification-service.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/case-notification-service.md
@@ -12,7 +12,6 @@ redirect_from:
 
 This page walks through deploying the Case Notification Service for case notification processing.
 
-
 1. Locate the Case Notification Service Helm chart in the [NEDSS-Helm repository][nedss-helm-case-notification-service-chart].
 1. Set the image repository and tag:
 

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/case-notification-service.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/case-notification-service.md
@@ -12,8 +12,6 @@ redirect_from:
 
 This page walks through deploying the Case Notification Service for case notification processing.
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 1. Locate the Case Notification Service Helm chart in the [NEDSS-Helm repository][nedss-helm-case-notification-service-chart].
 1. Set the image repository and tag:

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/data-extraction.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/data-extraction.md
@@ -12,7 +12,6 @@ redirect_from:
 
 This page walks through deploying the Data Extraction Service for case notification workflows.
 
-
 1. Locate the Data Extraction Service Helm chart in the [NEDSS-Helm repository][nedss-helm-data-extraction-service-chart].
 1. Set the image repository and tag:
 

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/data-extraction.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/data-extraction.md
@@ -12,8 +12,6 @@ redirect_from:
 
 This page walks through deploying the Data Extraction Service for case notification workflows.
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 1. Locate the Data Extraction Service Helm chart in the [NEDSS-Helm repository][nedss-helm-data-extraction-service-chart].
 1. Set the image repository and tag:

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/debezium.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/debezium.md
@@ -12,8 +12,6 @@ redirect_from:
 
 This page walks through enabling Change Data Capture (CDC) and deploying the Debezium source connector used by case notification services.
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 1. Enable Change Data Capture on `NBS_ODSE` for case notification. Sysadmin permissions are required. Then verify the configuration:
 

--- a/docs/deploy-nbs7/microservices-deployment/case-notification/debezium.md
+++ b/docs/deploy-nbs7/microservices-deployment/case-notification/debezium.md
@@ -12,7 +12,6 @@ redirect_from:
 
 This page walks through enabling Change Data Capture (CDC) and deploying the Debezium source connector used by case notification services.
 
-
 1. Enable Change Data Capture on `NBS_ODSE` for case notification. Sysadmin permissions are required. Then verify the configuration:
 
    ```sql

--- a/docs/deploy-nbs7/microservices-deployment/elasticsearch.md
+++ b/docs/deploy-nbs7/microservices-deployment/elasticsearch.md
@@ -20,7 +20,6 @@ This page walks through deploying Elasticsearch using the `elasticsearch-efs` He
 1. TOC
 {:toc}
 
-
 ## Deploy Elasticsearch using Helm
 
 1. Locate the Elasticsearch Helm chart in the [NEDSS-Helm repository][nedss-helm-elasticsearch-efs-chart].

--- a/docs/deploy-nbs7/microservices-deployment/elasticsearch.md
+++ b/docs/deploy-nbs7/microservices-deployment/elasticsearch.md
@@ -20,8 +20,6 @@ This page walks through deploying Elasticsearch using the `elasticsearch-efs` He
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 ## Deploy Elasticsearch using Helm
 

--- a/docs/deploy-nbs7/microservices-deployment/modernization-api.md
+++ b/docs/deploy-nbs7/microservices-deployment/modernization-api.md
@@ -20,8 +20,6 @@ This page walks through deploying the Modernization API using the `modernization
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 ## Deploy Modernization API using Helm
 

--- a/docs/deploy-nbs7/microservices-deployment/modernization-api.md
+++ b/docs/deploy-nbs7/microservices-deployment/modernization-api.md
@@ -20,7 +20,6 @@ This page walks through deploying the Modernization API using the `modernization
 1. TOC
 {:toc}
 
-
 ## Deploy Modernization API using Helm
 
 1. Locate the Modernization API Helm chart in the [NEDSS-Helm repository][nedss-helm-modernization-api-chart].

--- a/docs/deploy-nbs7/microservices-deployment/nbs-gateway.md
+++ b/docs/deploy-nbs7/microservices-deployment/nbs-gateway.md
@@ -20,7 +20,6 @@ The NBS Gateway service routes requests between NBS 7 microservices and the lega
 1. TOC
 {:toc}
 
-
 ## Deploy NBS Gateway using Helm
 
 1. Locate the NBS Gateway Helm chart in the [NEDSS-Helm repository][nedss-helm-nbs-gateway-chart].

--- a/docs/deploy-nbs7/microservices-deployment/nbs-gateway.md
+++ b/docs/deploy-nbs7/microservices-deployment/nbs-gateway.md
@@ -20,8 +20,6 @@ The NBS Gateway service routes requests between NBS 7 microservices and the lega
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 ## Deploy NBS Gateway using Helm
 

--- a/docs/deploy-nbs7/microservices-deployment/nifi.md
+++ b/docs/deploy-nbs7/microservices-deployment/nifi.md
@@ -20,7 +20,6 @@ This page walks through deploying NiFi using the `nifi-efs` Helm chart.
 1. TOC
 {:toc}
 
-
 ## Deploy NiFi using Helm
 
 > The NiFi ingress is disabled by default. To access the NiFi admin UI, set `ingress.enabled: true` in `values.yaml` before running the install command. Use a private domain name rather than a public one — NiFi has known security vulnerabilities.

--- a/docs/deploy-nbs7/microservices-deployment/nifi.md
+++ b/docs/deploy-nbs7/microservices-deployment/nifi.md
@@ -20,8 +20,6 @@ This page walks through deploying NiFi using the `nifi-efs` Helm chart.
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 ## Deploy NiFi using Helm
 

--- a/docs/deploy-nbs7/microservices-deployment/nnd-service/deploy-data-sync-service-api-cloud.md
+++ b/docs/deploy-nbs7/microservices-deployment/nnd-service/deploy-data-sync-service-api-cloud.md
@@ -18,8 +18,6 @@ Use these steps to install the NBS 7 Data Sync service API in your cloud environ
 1. TOC
 {:toc}
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 ## Prerequisites
 

--- a/docs/deploy-nbs7/microservices-deployment/nnd-service/deploy-data-sync-service-api-cloud.md
+++ b/docs/deploy-nbs7/microservices-deployment/nnd-service/deploy-data-sync-service-api-cloud.md
@@ -18,7 +18,6 @@ Use these steps to install the NBS 7 Data Sync service API in your cloud environ
 1. TOC
 {:toc}
 
-
 ## Prerequisites
 
 1. Locate the NND Service Helm chart in the [NEDSS-Helm repository][nedss-helm-nnd-service-chart]. Provide values for ECR repository, ECR image tag, database server endpoints, and ingress host in the `values.yaml` file.

--- a/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
+++ b/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
@@ -10,7 +10,6 @@ redirect_from:
 
 # Deploy and use the RTR Data Compare validation tool
 
-
 This page covers deploying and using the Data Compare tool to validate RTR output against classic ETL results.
 
 ## On this page

--- a/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
+++ b/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
@@ -10,8 +10,6 @@ redirect_from:
 
 # Deploy and use the RTR Data Compare validation tool
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 This page covers deploying and using the Data Compare tool to validate RTR output against classic ETL results.
 

--- a/docs/deploy-nbs7/real-time-reporting/debezium.md
+++ b/docs/deploy-nbs7/real-time-reporting/debezium.md
@@ -10,7 +10,6 @@ redirect_from:
 
 # Deploy Debezium for real-time reporting (RTR)
 
-
 This page covers steps to deploy the Debezium connector that captures change data from source tables and publishes events to Kafka topics for RTR processing.
 
 ## On this page

--- a/docs/deploy-nbs7/real-time-reporting/debezium.md
+++ b/docs/deploy-nbs7/real-time-reporting/debezium.md
@@ -10,8 +10,6 @@ redirect_from:
 
 # Deploy Debezium for real-time reporting (RTR)
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 This page covers steps to deploy the Debezium connector that captures change data from source tables and publishes events to Kafka topics for RTR processing.
 

--- a/docs/deploy-nbs7/real-time-reporting/kafka-connector.md
+++ b/docs/deploy-nbs7/real-time-reporting/kafka-connector.md
@@ -10,7 +10,6 @@ redirect_from:
 
 # Deploy the Kafka connector for real-time reporting (RTR)
 
-
 This page covers steps to deploy the Kafka sink connector that consumes RTR topics and writes transformed data into reporting tables.
 
 ## On this page

--- a/docs/deploy-nbs7/real-time-reporting/kafka-connector.md
+++ b/docs/deploy-nbs7/real-time-reporting/kafka-connector.md
@@ -10,8 +10,6 @@ redirect_from:
 
 # Deploy the Kafka connector for real-time reporting (RTR)
 
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 This page covers steps to deploy the Kafka sink connector that consumes RTR topics and writes transformed data into reporting tables.
 

--- a/docs/deploy-nbs7/real-time-reporting/real-time-reporting.md
+++ b/docs/deploy-nbs7/real-time-reporting/real-time-reporting.md
@@ -19,8 +19,6 @@ redirect_from:
 
 > This feature is in Beta preview and not production ready.
 {: .important }
-> This page applies to NBS {{ site.version_latest }}. Script links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 Real-time reporting (RTR) is an optional add-on for NBS 7. RTR reduces reporting latency from as long as 24 hours to between 5 minutes and 1 hour. It uses Kafka Connect to stream row-level changes from source tables, which reduces reliance on the `MasterETL` batch process.
 

--- a/docs/deploy-nbs7/real-time-reporting/rtr-java-services.md
+++ b/docs/deploy-nbs7/real-time-reporting/rtr-java-services.md
@@ -12,8 +12,6 @@ redirect_from:
 
 > The Java reporting services are being consolidated in an upcoming release. The service validation URLs reflect the NBS {{ site.version_latest }} configuration.
 {: .warning }
-> This page applies to NBS {{ site.version_latest }}. Helm chart links are pinned to `{{ site.version_latest_tag }}`.
-{: .note }
 
 This page covers deploying the RTR Java services that process streamed events from Kafka and load domain-specific reporting data.
 

--- a/docs/maintain-nbs7.md
+++ b/docs/maintain-nbs7.md
@@ -10,6 +10,9 @@ description: Operational guidance for maintaining your NBS 7 deployment after go
 
 This section covers the operational tasks that keep your NBS 7 environment healthy after go-live. It is intended for system administrators who maintain the infrastructure, platform components, and supporting configuration for a running NBS 7 deployment.
 
+> The procedures in this section reflect NBS {{ site.version_latest }}. For earlier releases, see **Previous Versions** in the sidebar.
+{: .note }
+
 Use this section for recurring maintenance work such as upgrades, infrastructure version changes, and operational configuration updates. Work through the pages that match the change you need to make.
 
 <!--

--- a/docs/revision-history.md
+++ b/docs/revision-history.md
@@ -1,0 +1,17 @@
+---
+title: Revision history
+layout: page
+nav_order: 5
+description: A record of significant updates to the NBS 7 System Administrator Guide.
+---
+
+# Revision history
+
+This table records significant updates to the NBS 7 System Administrator Guide. Entries are added for each NBS release and for substantial content changes between releases.
+
+| Date | Description | Author |
+|:-----|:------------|:-------|
+| April 28, 2026 | Replace NGINX with [Traefik instructions](/NEDSS-SystemAdminGuide/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.html#deploy-traefik-ingress-controller) | Kate Saul, Jill Shaheen (Skylight Digital) |
+| April 24, 2026 | [RTR deployment](/NEDSS-SystemAdminGuide/docs/deploy-nbs7/real-time-reporting/real-time-reporting.html) content audit (7.12) | Jill Shaheen (Skylight Digital) |
+| April 17, 2026 | Full site restructure | Jill Shaheen (Skylight Digital) |
+| August 19, 2025 | 7.11.0 Minor Release | Anand Logan, Upasana Pattnaik, Kashyap Ramakur, Aaron Chapman, Duc Nguyen, Chuck Moss, Serban Zamfir |

--- a/index.md
+++ b/index.md
@@ -10,6 +10,9 @@ description: Overview of the NBS system administration guide, including preparat
 The National Electronic Disease Surveillance System (NEDSS) Base System (NBS) is a CDC-developed disease surveillance system that health departments use to manage reportable disease data. NBS 7 is the modernized version of the platform, designed for deployment and operation on cloud-based infrastructure. This documentation supports the administration lifecycle for NBS 7, including planning, deployment, validation, and maintenance.
 {: .fw-300}
 
+> The content in this guide reflects NBS {{ site.version_latest }}. For procedures from earlier releases, see **Previous Versions** in the sidebar.
+{: .note }
+
 ---
 
 ## Purpose and scope

--- a/index.md
+++ b/index.md
@@ -38,12 +38,3 @@ NBS 7 supports AWS and Azure as runtime options. The platform uses a cloud-agnos
 The primary audience is system administrators at state, tribal, local, and territorial health departments who install, operate, and maintain NBS 7. The content assumes familiarity with your cloud platform, Kubernetes, Terraform, Helm, and related administration tasks. You need administrator-level access to your runtime environment and a local system with required prerequisites installed.
 
 For more information on NBS, see the official CDC [National Electronic Disease Surveillance System Base System (NBS)](https://www.cdc.gov/nbs/php/index.html) website.
-
-## Revision history
-
-| Date         | Description        | Author |
-|:-------------|:------------------|:-------|
-| April 28, 2026 | Replace NGINX with [Traefik instructions](/NEDSS-SystemAdminGuide/docs/deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.html#deploy-traefik-ingress-controller) | Kate Saul, Jill Shaheen (Skylight Digital) |
-| April 24, 2026 | [RTR deployment](/NEDSS-SystemAdminGuide/docs/deploy-nbs7/real-time-reporting/real-time-reporting.html) content audit (7.12) | Jill Shaheen (Skylight Digital) |
-| April 17, 2026 | Full site restructure | Jill Shaheen (Skylight Digital) |
-| August 19, 2025 | 7.11.0 Minor Release | Anand Logan, Upasana Pattnaik, Kashyap Ramakur, Aaron Chapman, Duc Nguyen, Chuck Moss, Serban Zamfir |


### PR DESCRIPTION
## Summary

Replaces per-page version callouts with a persistent version banner injected
via JavaScript (`_includes/head_custom.html`, `_sass/custom/custom.scss`).
The banner shows the current version on live pages and automatically detects
the archived version from the URL on Previous Versions pages ("Archived: NBS
7.11.0"), so the banner requires no find-and-replace at release time. Removes
the "This page applies to NBS X.XX" callout from 15 individual deploy pages,
which are now redundant with the banner.

Adds version note callouts to the Introduction, Deploy NBS 7, and Maintain NBS
7 section landing pages. Updates the Deploy NBS 7 H1 to use `{{ site.version_latest }}`
and documents the front matter title as a manual release checklist step (Jekyll
does not process Liquid in front matter). Moves the revision history table from
`index.md` to a standalone `docs/revision-history.md` page at nav_order 5.

Overhauls the release checklist: corrects step ordering so the archive branch
is cut before version variables are updated on `main`, adds a release workflow
overview explaining the two-phase sequence, replaces the 25-row
version-sensitive pages table with a grep step and a 5-row manual-review table,
and moves Jira ticket creation into "Before you begin."

## Test plan

- [ ] Site builds without errors (`bundle exec jekyll serve` or `docker compose up`)
- [ ] Markdown lint passes (`npm run lint`)
- [ ] Version banner renders correctly on current-release pages (e.g., "NBS 7.12")
- [ ] Version note callouts render on Introduction, Deploy NBS 7, and Maintain NBS 7 landing pages
- [ ] Deploy NBS 7 H1 resolves to "Deploy NBS 7.12" on the built site
- [ ] Archived version banner shows "Archived: NBS 7.11.0" on Previous Versions pages