### PR TITLE
[STLT-433 & STLT-463] Document DataCompare IRSA role requirement for S3 access and edit TF samples path

### DIFF
--- a/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
+++ b/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
@@ -39,6 +39,17 @@ configuration files
    {: .note }
 
 1. Update the `terraform.tfvars` and `terraform.tf` with your environment-specific values by following the [NEDSS infrastructure sample configuration instructions][nedss-infra-aws-samples-readme]
+
+   If you plan to deploy the Data Compare tool, also add the following variables to your `terraform.tfvars` before running `terraform apply`:
+
+   ```hcl
+   create_datacompare_irsa              = true
+   datacompare_s3_bucket_name           = "<your-s3-bucket-name>"
+   datacompare_s3_bucket_keyname_prefix = "<your-key-prefix>"
+   datacompare_namespace_and_service    = ["<namespace>:<service-account-name>"]
+   ```
+
+   This creates the IAM role (`<eks-cluster-name>-datacompare-role`) and S3 access policy required by the Data Compare pods. The role ARN is referenced during [Data Compare deployment](../../deploy-nbs7/real-time-reporting/data-compare-tool.html).
 1. Review the inbound rules on the security groups attached to your database instance and ensure that the CIDR you intend to use with your NBS 7 VPC (`modern-cidr`) is allowed to access the database.
     - a. For example if the `modern-cidr` is `10.20.0.0/16`, there should be at least one rule in a security group associated to your database that allows MSSQL inbound access from your `modern-cidr` block
     ![mssql-inbound-from-modern-cidr](../images/myssql-inbound-from-modern-cidr.png)

--- a/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
+++ b/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
@@ -21,24 +21,23 @@ redirect_from:
 
 ## Overview
 
-This page covers the first deployment phase: provisioning the AWS cloud environment using Terraform. Complete the steps in this section before proceeding to [Initial Kubernetes Deployment](../initial-kubernetes-deployment/).
+This page covers the first deployment phase: provisioning the AWS cloud environment using Terraform. Complete the steps in this section before proceeding to [Initial Kubernetes Deployment](../../deploy-nbs7/initial-kubernetes-deployment/initial-kubernetes-deployment.html).
 
 1. Go to the [NEDSS-Infrastructure {{ site.version_latest_tag }} release page][nedss-infra-release-page]. Under **Assets**, download the `nbs-infrastructure-{{ site.version_latest_tag }}.zip` file.
 1. Open a terminal (bash, macOS Terminal, CloudShell, or PowerShell) and unzip the downloaded file.
 1. Create a new directory with an easily identifiable name e.g nbs7-mySTLT-test in /terraform/aws/ to hold your environment specific
 configuration files
-1. Copy terraform/aws/samples/NBS7_standard to the new directory and change into the new directory (Note: the samples directory
-   contains other options than "standard", view the README file in that directory to chose most appropriate starting point)
+1. Copy `terraform/aws/samples/archive/NBS7_standard` to the new directory and change into the new directory.
 
    ```bash
-   cp -pr terraform/aws/samples/NBS7_standard/* terraform/aws/nbs7-mySTLT-test
+   cp -pr terraform/aws/samples/archive/NBS7_standard/* terraform/aws/nbs7-mySTLT-test
    cd terraform/aws/nbs7-mySTLT-test
    ```
 
    > Before you edit `terraform.tfvars` and `terraform.tf` files below, you can reference detailed information for each TF module under `terraform/aws/app-infrastructure` in a README file in each module's directory. Do not edit files in the individual modules.
    {: .note }
 
-1. Update the `terraform.tfvars` and `terraform.tf` with your environment-specific values by following the [NEDSS infrastructure sample configuration instructions][nedss-infra-aws-samples-readme]
+1. Update the `terraform.tfvars` and `terraform.tf` with your environment-specific values.
 
    If you plan to deploy the Data Compare tool, also add the following variables to your `terraform.tfvars` before running `terraform apply`:
 
@@ -123,4 +122,3 @@ configuration files
 You have now installed your core infrastructure and Kubernetes cluster. Next, see [Initial Kubernetes Deployment](../initial-kubernetes-deployment/initial-kubernetes-deployment.html) to configure your cluster using Helm charts.
 
 [nedss-infra-release-page]: <https://github.com/CDCgov/NEDSS-Infrastructure/releases/tag/{{ site.version_latest_tag }}>
-[nedss-infra-aws-samples-readme]: <https://github.com/CDCgov/NEDSS-Infrastructure/blob/{{ site.version_latest_tag }}/terraform/aws/samples/README.md>

--- a/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
+++ b/docs/deploy-nbs7/deploy-on-aws/provision-aws.md
@@ -39,13 +39,13 @@ configuration files
 
 1. Update the `terraform.tfvars` and `terraform.tf` with your environment-specific values.
 
-   If you plan to deploy the Data Compare tool, also add the following variables to your `terraform.tfvars` before running `terraform apply`:
+   If you plan to deploy the Data Compare tool, also add the following variables to your `terraform.tfvars` before running `terraform apply`. If you deployed to a non-default namespace, adjust the `datacompare_namespace_and_service` value accordingly.
 
    ```hcl
    create_datacompare_irsa              = true
    datacompare_s3_bucket_name           = "<your-s3-bucket-name>"
    datacompare_s3_bucket_keyname_prefix = "<your-key-prefix>"
-   datacompare_namespace_and_service    = ["<namespace>:<service-account-name>"]
+   datacompare_namespace_and_service = ["default:data-compare-api-service", "default:data-compare-processor-service"]
    ```
 
    This creates the IAM role (`<eks-cluster-name>-datacompare-role`) and S3 access policy required by the Data Compare pods. The role ARN is referenced during [Data Compare deployment](../../deploy-nbs7/real-time-reporting/data-compare-tool.html).

--- a/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
+++ b/docs/deploy-nbs7/real-time-reporting/data-compare-tool.md
@@ -38,6 +38,8 @@ Before deploying the Data Compare tool, verify the following:
 
 - Access to a cloud storage bucket for data exchange between the API and Processor services. These steps currently use Amazon S3. If you are not using Amazon S3, consult your cloud administrator for equivalent storage configuration.
 
+  For AWS deployments, an IAM role granting the Data Compare pods access to S3 must be provisioned before deployment. This role is created by Terraform in NEDSS-Infrastructure when `create_datacompare_irsa = true` is set in your `terraform.tfvars`. The role is named `<eks-cluster-name>-datacompare-role`. See [Provision the AWS environment](../deploy-on-aws/provision-aws.html) for details.
+
 - Keycloak configured with the Data Compare API profile: [NEDSS-Helm/charts/keycloak/extra][nedss-helm-keycloak-extra]
 
 If your Keycloak pod uses a name or namespace other than the default, update the `authUri` in your `values.yaml`:
@@ -79,6 +81,16 @@ The Helm chart is located in `charts/data-compare-api-service` in the [NEDSS-Hel
      region: "AWS REGION"
      bucketName: "S3 BucketName"
    ```
+
+1. For AWS deployments, add the IRSA role ARN to `values.yaml` to grant the pod access to S3:
+
+   ```yaml
+   serviceAccount:
+     annotations:
+       eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<eks-cluster-name>-datacompare-role"
+   ```
+
+   Replace `<ACCOUNT_ID>` and `<eks-cluster-name>` with your values. The role is created during infrastructure provisioning. See [Provision the AWS environment](../deploy-on-aws/provision-aws.html) for details.
 
 1. Install the Helm chart:
 
@@ -129,6 +141,16 @@ The Helm chart is located in `charts/data-compare-processor-service` in the [NED
      region: "AWS REGION"
      bucketName: "S3 BucketName"
    ```
+
+1. For AWS deployments, add the IRSA role ARN to `values.yaml` to grant the pod access to S3:
+
+   ```yaml
+   serviceAccount:
+     annotations:
+       eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<eks-cluster-name>-datacompare-role"
+   ```
+
+   Replace `<ACCOUNT_ID>` and `<eks-cluster-name>` with your values. The role is created during infrastructure provisioning. See [Provision the AWS environment](../deploy-on-aws/provision-aws.html) for details.
 
 1. Install the Helm chart:
 


### PR DESCRIPTION
**[STLT-433](https://cdc-nbs.atlassian.net/browse/STLT-433):**  DataCompare requires an IAM role to access the S3 bucket used for RTR validation. This role (`<eks-cluster-name>-datacompare-role`) is created by Terraform in NEDSS-Infrastructure when `create_datacompare_irsa = true` is set.

**[STLT-463](https://cdc-nbs.atlassian.net/browse/STLT-463):** The Terrform samples directory has been archived and the documentation still showed the old path. The docs also referenced a README that wasn't helpful.

## Changes

- **data-compare-tool.md**: Expanded the S3 prerequisite to explain the IRSA role requirement and naming convention. Added a step to both the API and Processor deploy sections showing how to annotate the service account with the role ARN in `values.yaml` (AWS only).
- **provision-aws.md**: Added a callout under the tfvars configuration step listing the four variables required to enable Data Compare IRSA (`create_datacompare_irsa`, `datacompare_s3_bucket_name`, `datacompare_s3_bucket_keyname_prefix`, `datacompare_namespace_and_service`).
- **provision-aws.md**: Updated the samples directory path in step 4 along with the path in the `cp` command. Removed 2 references to the samples README (steps 4 and 5).

## Open question

The `datacompare_namespace_and_service` Terraform variable is documented with a placeholder (`["<namespace>:<service-account-name>"]`). Is there an expected default value for a standard deployment? If so, I can update both the provision-aws callout and the Data Compare prerequisites with a concrete value.