### PR TITLE
Fix "No module named web2word" in review-doc workflow

### DIFF
--- a/.github/workflows/review-doc.yml
+++ b/.github/workflows/review-doc.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Convert the chapter to Word
         env:
           CHAPTER: ${{ github.event.inputs.chapter }}
+          # The converter is cloned into .web2word/ but not pip-installed as a
+          # package, so put its parent on the path for `python -m web2word`.
+          PYTHONPATH: .web2word
         run: |
           set -euo pipefail
           # Normalize: strip a leading slash, a leading "docs/", and a trailing ".html".


### PR DESCRIPTION
The converter is cloned into .web2word/ and its dependencies installed, but the package itself was never on Python's path, so `python -m web2word` failed from the content-repo working directory. Set PYTHONPATH=.web2word on the Convert step.