### PR TITLE
Clarify review doc always builds from preview

### DIFF
--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -109,7 +109,8 @@ setup needed:
 2. Enter the chapter path under `docs/`, without `.html` — for example
    `before-you-deploy`, or a deeper page such as
    `deploy-nbs7/full-deploy/provision-cloud-infrastructure/provision-cloud-environment`.
-   Leave the branch as `preview`.
+   The workflow builds from the `preview` branch, so make sure your content is on
+   `preview` first (step 3 above).
 3. When the run finishes (~1 minute), **refresh the run page** — the
    **Artifacts** panel only appears after a reload. Download the `.docx` under
    **eclearance-review-doc**.


### PR DESCRIPTION
The workflow builds from the preview branch (no branch selector), so direct contributors to push their content to preview first rather than referencing a branch input.