### PR TITLE
Bump markdownlint-cli2 to 0.23.2 to patch js-yaml DoS (Dependabot #30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "nedss-systemadminGuide",
       "devDependencies": {
         "markdown-link-check": "^3.12.0",
-        "markdownlint-cli2": "^0.23.1"
+        "markdownlint-cli2": "^0.23.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1109,14 +1109,14 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.1.tgz",
-      "integrity": "sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.2.1",
-        "js-yaml": "5.2.1",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
         "markdown-it": "14.3.0",
@@ -1149,9 +1149,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "link-check": "npm run link-check:internal && npm run link-check:external && npm run link-check:github:changed"
   },
   "devDependencies": {
-    "markdownlint-cli2": "^0.23.1",
-    "markdown-link-check": "^3.12.0"
+    "markdown-link-check": "^3.12.0",
+    "markdownlint-cli2": "^0.23.2"
   }
 }


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#30](https://github.com/CDCgov/NEDSS-SystemAdminGuide/security/dependabot/30) — an exponential-time (ReDoS-style) denial-of-service in **js-yaml** flow-collection parsing (affected `>= 5.0.0, <= 5.2.1`, patched in `5.2.2`).

The vulnerable `js-yaml` is a **transitive, dev-only** dependency reached via `markdownlint-cli2`. This takes Dependabot's recommended path of updating the parent package rather than adding an override:

| Package | Before | After |
|---|---|---|
| `markdownlint-cli2` | 0.23.1 | **0.23.2** |
| `js-yaml` (transitive) | 5.2.1 (vulnerable) | **5.2.2** (patched) |

## Verification

- `npm audit` → **0 vulnerabilities**
- Lockfile: nested `js-yaml` now `5.2.2`; no `5.2.1` remaining
- `npm run lint` runs clean on 70 files (markdownlint-cli2 v0.23.2)

## Risk

`markdownlint-cli2` is a build/lint tool that only parses this repo's own Markdown/config — it never calls `js-yaml.load()` on untrusted network input, so real-world exposure was low. This clears the alert regardless.